### PR TITLE
Photo essay alt

### DIFF
--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -781,11 +781,12 @@ class PhotoEssay extends CustomPostType {
 		$slide_caption  = $fields['slide_caption'][$id] ? $fields['slide_caption'][$id] : '';
 		$slide_image_id = !is_string($id) ? intval($fields['slide_image'][$id]) : $id;
 		$slide_image    = !is_string($slide_image_id) ? get_post($slide_image_id) : null;
+		$slide_header   = $fields['slide_title'][$id] ? $fields['slide_title'][$id] : get_the_title($slide_image);
 	?>
 		<li class="custom_repeatable postbox<?php if (is_string($id)) {?> cloner" style="display:none;<?php } ?>">
 			<div class="handlediv" title="Click to toggle"> </div>
 				<h3 class="hndle">
-				<span>Slide - </span><span class="slide-handle-header"><?=$slide_title?></span>
+				<span>Slide - </span><span class="slide-handle-header"><?php echo $slide_header; ?></span>
 			</h3>
 			<table class="form-table">
 			<input type="hidden" name="meta_box_nonce" value="<?=wp_create_nonce('nonce-content')?>"/>

--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -747,6 +747,11 @@ class PhotoEssay extends CustomPostType {
 	public static function get_single_slide_meta() {
 		$single_slide_meta = array(
 			array(
+				'id'	=> 'ss_slide_alt',
+				'val'	=> $_POST['ss_slide_alt'],
+				'type'  => 'text',
+			),
+			array(
 				'id'	=> 'ss_slide_title',
 				'val'	=> $_POST['ss_slide_title'],
 				'type'  => 'text',
@@ -771,6 +776,7 @@ class PhotoEssay extends CustomPostType {
 	 **/
 	public static function display_cloneable_fieldset($fields, $id=null) {
 		$id             = $id !== null ? intval($id) : 'xxxxxx';
+		$slide_alt    	= $fields['slide_alt'][$id] ? $fields['slide_alt'][$id] : '';
 		$slide_title    = $fields['slide_title'][$id]   ? $fields['slide_title'][$id] : '';
 		$slide_caption  = $fields['slide_caption'][$id] ? $fields['slide_caption'][$id] : '';
 		$slide_image_id = !is_string($id) ? intval($fields['slide_image'][$id]) : $id;
@@ -784,9 +790,9 @@ class PhotoEssay extends CustomPostType {
 			<table class="form-table">
 			<input type="hidden" name="meta_box_nonce" value="<?=wp_create_nonce('nonce-content')?>"/>
 				<tr>
-					<th><label for="ss_slide_title[<?=$id?>]">Title</label></th>
+					<th><label for="ss_slide_alt[<?php echo $id; ?>]">Image Alt Text</label></th>
 					<td>
-						<input type="text" name="ss_slide_title[<?=$id?>]" id="ss_slide_title[<?=$id?>]" value="<?=$slide_title?>" />
+						<input type="text" name="ss_slide_alt[<?php echo $id; ?>]" id="ss_slide_alt[<?php echo $id; ?>]" value="<?php echo $slide_alt; ?>" />
 					</td>
 				</tr>
 				<tr>
@@ -834,6 +840,13 @@ class PhotoEssay extends CustomPostType {
 						<input type="text" id="file_img_<?=$slide_image_id?>" value="<?=$slide_image_id?>" name="ss_slide_image[<?=$id?>]">
 					</td>
 				</tr>
+				<tr>
+					<th><label for="ss_slide_title[<?php echo $id; ?>]">DEPRECATED: Title</label></th>
+					<td>
+						<p class="description"><strong><em>This feature is deprecated and is left in place for backward compatibility. You can now use the Alt Text field above to add alt text to each slide image.</em></strong></p>
+						<input type="text" name="ss_slide_title[<?php echo $id; ?>]" id="ss_slide_title[<?php echo $id; ?>]" value="<?php echo $slide_title; ?>" />
+					</td>
+				</tr>
 			</table>
 			<a class="repeatable-remove button" href="#">Remove Slide</a>
 		</li>
@@ -846,14 +859,16 @@ class PhotoEssay extends CustomPostType {
 	 **/
 	public static function display_slide_meta_fields($post) {
 		// Get any already-existing values for these fields:
+		$slide_alt		= get_post_meta($post->ID, 'ss_slide_alt', TRUE);
 		$slide_title	= get_post_meta($post->ID, 'ss_slide_title', TRUE);
 		$slide_caption	= get_post_meta($post->ID, 'ss_slide_caption', TRUE);
 		$slide_image	= get_post_meta($post->ID, 'ss_slide_image', TRUE);
 		$slide_order    = get_post_meta($post->ID, 'ss_slider_slideorder', TRUE);
 		$args = array(
-			'slide_title' => $slide_title,
+			'slide_alt' 	=> $slide_alt,
+			'slide_title' 	=> $slide_title,
 			'slide_caption' => $slide_caption,
-			'slide_image' => $slide_image
+			'slide_image' 	=> $slide_image
 		);
 		?>
 		<div id="ss_slides_wrapper">

--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -831,7 +831,7 @@ class PhotoEssay extends CustomPostType {
 				<tr>
 					<th><label for="ss_slide_title[<?php echo $id; ?>]">DEPRECATED: Title</label></th>
 					<td>
-						<p class="description"><strong><em>This feature is deprecated and is left in place for backward compatibility. This feature is deprecated and is left in place for backward compatibility. Edit the image's alt text from the Media Library.</em></strong></p>
+						<p class="description"><strong><em>This feature is deprecated and is left in place for backward compatibility. Edit the image's alt text from the Media Library.</em></strong></p>
 						<input type="text" name="ss_slide_title[<?php echo $id; ?>]" id="ss_slide_title[<?php echo $id; ?>]" value="<?php echo $slide_title; ?>" />
 					</td>
 				</tr>

--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -834,11 +834,11 @@ class PhotoEssay extends CustomPostType {
 								$slide_image_id = '';
 							}
 						?>
-						<a target="_blank" href="<?=$url?>">
-							<img src="<?=$url?>" style="max-width: 400px; height: auto;" /><br/>
+
+							<img src="<?php echo $url; ?>" style="max-width: 400px; height: auto;" /><br/>
 							<span><?php if (!empty($slide_image)) { print $slide_image->post_title; }?></span>
-						</a><br />
-						<input type="text" id="file_img_<?=$slide_image_id?>" value="<?=$slide_image_id?>" name="ss_slide_image[<?=$id?>]">
+						<br />
+						<input type="text" id="file_img_<?php echo $slide_image_id; ?>" value="<?php echo $slide_image_id; ?>" name="ss_slide_image[<?php echo $id; ?>]">
 					</td>
 				</tr>
 				<tr>

--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -747,11 +747,6 @@ class PhotoEssay extends CustomPostType {
 	public static function get_single_slide_meta() {
 		$single_slide_meta = array(
 			array(
-				'id'	=> 'ss_slide_alt',
-				'val'	=> $_POST['ss_slide_alt'],
-				'type'  => 'text',
-			),
-			array(
 				'id'	=> 'ss_slide_title',
 				'val'	=> $_POST['ss_slide_title'],
 				'type'  => 'text',
@@ -776,7 +771,6 @@ class PhotoEssay extends CustomPostType {
 	 **/
 	public static function display_cloneable_fieldset($fields, $id=null) {
 		$id             = $id !== null ? intval($id) : 'xxxxxx';
-		$slide_alt    	= $fields['slide_alt'][$id] ? $fields['slide_alt'][$id] : '';
 		$slide_title    = $fields['slide_title'][$id]   ? $fields['slide_title'][$id] : '';
 		$slide_caption  = $fields['slide_caption'][$id] ? $fields['slide_caption'][$id] : '';
 		$slide_image_id = !is_string($id) ? intval($fields['slide_image'][$id]) : $id;
@@ -790,12 +784,6 @@ class PhotoEssay extends CustomPostType {
 			</h3>
 			<table class="form-table">
 			<input type="hidden" name="meta_box_nonce" value="<?=wp_create_nonce('nonce-content')?>"/>
-				<tr>
-					<th><label for="ss_slide_alt[<?php echo $id; ?>]">Image Alt Text</label></th>
-					<td>
-						<input type="text" name="ss_slide_alt[<?php echo $id; ?>]" id="ss_slide_alt[<?php echo $id; ?>]" value="<?php echo $slide_alt; ?>" />
-					</td>
-				</tr>
 				<tr>
 					<th><label for="ss_slide_caption[<?=$id?>]">Slide Caption</label></th>
 					<td>
@@ -834,8 +822,8 @@ class PhotoEssay extends CustomPostType {
 								$slide_image_id = '';
 							}
 						?>
-							<img src="<?php echo $url; ?>" style="max-width: 400px; height: auto;" /><br/>
-							<span><?php if (!empty($slide_image)) { print $slide_image->post_title; }?></span>
+						<img src="<?php echo $url; ?>" style="max-width: 400px; height: auto;" /><br/>
+						<span><?php if (!empty($slide_image)) { print $slide_image->post_title; }?></span>
 						<br />
 						<input type="text" id="file_img_<?php echo $slide_image_id; ?>" value="<?php echo $slide_image_id; ?>" name="ss_slide_image[<?php echo $id; ?>]">
 					</td>
@@ -843,7 +831,7 @@ class PhotoEssay extends CustomPostType {
 				<tr>
 					<th><label for="ss_slide_title[<?php echo $id; ?>]">DEPRECATED: Title</label></th>
 					<td>
-						<p class="description"><strong><em>This feature is deprecated and is left in place for backward compatibility. You can now use the Alt Text field above to add alt text to each slide image.</em></strong></p>
+						<p class="description"><strong><em>This feature is deprecated and is left in place for backward compatibility. This feature is deprecated and is left in place for backward compatibility. Edit the image's alt text from the Media Library.</em></strong></p>
 						<input type="text" name="ss_slide_title[<?php echo $id; ?>]" id="ss_slide_title[<?php echo $id; ?>]" value="<?php echo $slide_title; ?>" />
 					</td>
 				</tr>
@@ -859,13 +847,11 @@ class PhotoEssay extends CustomPostType {
 	 **/
 	public static function display_slide_meta_fields($post) {
 		// Get any already-existing values for these fields:
-		$slide_alt  	= get_post_meta($post->ID, 'ss_slide_alt', TRUE);
 		$slide_title	= get_post_meta($post->ID, 'ss_slide_title', TRUE);
 		$slide_caption	= get_post_meta($post->ID, 'ss_slide_caption', TRUE);
 		$slide_image	= get_post_meta($post->ID, 'ss_slide_image', TRUE);
 		$slide_order	= get_post_meta($post->ID, 'ss_slider_slideorder', TRUE);
 		$args = array(
-			'slide_alt' 	=> $slide_alt,
 			'slide_title' 	=> $slide_title,
 			'slide_caption' => $slide_caption,
 			'slide_image' 	=> $slide_image

--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -834,7 +834,6 @@ class PhotoEssay extends CustomPostType {
 								$slide_image_id = '';
 							}
 						?>
-
 							<img src="<?php echo $url; ?>" style="max-width: 400px; height: auto;" /><br/>
 							<span><?php if (!empty($slide_image)) { print $slide_image->post_title; }?></span>
 						<br />
@@ -860,11 +859,11 @@ class PhotoEssay extends CustomPostType {
 	 **/
 	public static function display_slide_meta_fields($post) {
 		// Get any already-existing values for these fields:
-		$slide_alt		= get_post_meta($post->ID, 'ss_slide_alt', TRUE);
+		$slide_alt  	= get_post_meta($post->ID, 'ss_slide_alt', TRUE);
 		$slide_title	= get_post_meta($post->ID, 'ss_slide_title', TRUE);
 		$slide_caption	= get_post_meta($post->ID, 'ss_slide_caption', TRUE);
 		$slide_image	= get_post_meta($post->ID, 'ss_slide_image', TRUE);
-		$slide_order    = get_post_meta($post->ID, 'ss_slider_slideorder', TRUE);
+		$slide_order	= get_post_meta($post->ID, 'ss_slider_slideorder', TRUE);
 		$args = array(
 			'slide_alt' 	=> $slide_alt,
 			'slide_title' 	=> $slide_title,

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -458,8 +458,6 @@ WebcomAdmin.sliderMetaBoxes = function($) {
       $('label[for^="ss_slide_image["]', newSlide)
         .parent('th')
           .next('td')
-            .find('a')
-              .attr('href', attachment_url)
               .find('img')
                 .attr('src', attachment_url)
                 .siblings('span')

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -253,7 +253,7 @@ WebcomAdmin.sliderMetaBoxes = function($) {
             inputID = getInputID(slide.find(keyField).attr('name')),
             inputs = slide.find('input[name*="['+inputID+']"]'),
             textareas = slide.find('textarea[name*="['+inputID+']"]'),
-            fields = [inputs, textareas];
+            fields = inputs.add(textareas);
 
         $.each(fields, function() {
           if (($(this).val() && typeof $(this).val() !== 'undefined' && $(this).val !== '') || $(this).hasClass('has-value')) {

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -463,7 +463,6 @@ WebcomAdmin.sliderMetaBoxes = function($) {
                 .siblings('span')
                   .text(attachment_filename);
 
-      $('input[id^="ss_slide_alt"]', newSlide).attr('value', attachment_alt);
       $('textarea[id^="ss_slide_caption"]', newSlide).attr('value', attachment_caption);
       $('input[id^="file_img_"]', newSlide).attr('value', attachment_id);
       newSlide.insertAfter(newSlideSibling).show();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -464,7 +464,6 @@ WebcomAdmin.sliderMetaBoxes = function($) {
                 .siblings('span')
                   .text(attachment_filename);
 
-      $('input[id^="ss_slide_title"]', newSlide).attr('value', attachment_title);
       $('textarea[id^="ss_slide_caption"]', newSlide).attr('value', attachment_caption);
       $('input[id^="file_img_"]', newSlide).attr('value', attachment_id);
       newSlide.insertAfter(newSlideSibling).show();

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -423,6 +423,7 @@ WebcomAdmin.sliderMetaBoxes = function($) {
       var attachment_id = attachment.attributes.id,
           attachment_filename = attachment.attributes.filename,
           attachment_url = attachment.attributes.url,
+          attachment_alt = attachment.attributes.alt,
           attachment_title = attachment.attributes.title,
           attachment_caption = attachment.attributes.caption;
 
@@ -464,6 +465,7 @@ WebcomAdmin.sliderMetaBoxes = function($) {
                 .siblings('span')
                   .text(attachment_filename);
 
+      $('input[id^="ss_slide_alt"]', newSlide).attr('value', attachment_alt);
       $('textarea[id^="ss_slide_caption"]', newSlide).attr('value', attachment_caption);
       $('input[id^="file_img_"]', newSlide).attr('value', attachment_id);
       newSlide.insertAfter(newSlideSibling).show();

--- a/versions/v4/functions.php
+++ b/versions/v4/functions.php
@@ -348,6 +348,7 @@ function display_photo_essay_slideshow( $photo_essay, $slug=null, $caption_color
 	// Get rid of blank array entries
 	$slide_order = array_filter( explode( ',', $slide_order ), 'strlen' );
 	$slide_caption = get_post_meta( $photo_essay->ID, 'ss_slide_caption', TRUE );
+	$slide_alt = get_post_meta( $photo_essay->ID, 'ss_slide_alt', TRUE );
 	$slide_title = get_post_meta( $photo_essay->ID, 'ss_slide_title', TRUE );
 	$slide_image = get_post_meta( $photo_essay->ID, 'ss_slide_image', TRUE );
 
@@ -385,10 +386,11 @@ function display_photo_essay_slideshow( $photo_essay, $slug=null, $caption_color
 
 				$s = $slide_order[$i];
 				$image = wp_get_attachment_image_src( $slide_image[$s], 'full' );
+				$alt = $slide_alt[$s] ? $slide_alt[$s] : $slide_title[$s];
 				?>
 				<div class="ss-slide-wrapper">
 					<div class="ss-slide<?php echo $i + $photo_essay_offset == 0 ? ' ss-first-slide ss-current' : ''; ?><?php echo $i == $slide_count - 1 ? ' ss-last-slide' : ''; ?>" data-id="<?php echo $i + 1 + $photo_essay_offset; ?>" data-width="<?php echo $image[1]; ?>" data-height="<?php echo $image[2]; ?>">
-						<img src="<?php echo $image[0]; ?>" alt="<?php echo $slide_title[$s]; ?>" />
+						<img src="<?php echo $image[0]; ?>" alt="<?php echo $alt; ?>" title="<?php echo $slide_title[$s]; ?>" />
 					</div>
 				</div>
 			<?php

--- a/versions/v4/functions.php
+++ b/versions/v4/functions.php
@@ -175,7 +175,7 @@ add_filter( 'wp_kses_allowed_html', 'v4_add_kses_whitelisted_attributes', 11, 2 
 /**
  * Displays a full photo essay or photo essay story.
  **/
-function display_photo_essay_item( $orientation, $item_id, $image_url, $title, $caption, $alternate=false ) {
+function display_photo_essay_item( $orientation, $item_id, $image_url, $title, $alt, $caption, $alternate=false ) {
 	ob_start();
 ?>
 	<figure class="photo-essay-item photo-essay-item-<?php echo $orientation; ?> <?php if ( $alternate ) { ?>alternate<?php } ?>" id="<?php echo $item_id; ?>">
@@ -185,7 +185,7 @@ function display_photo_essay_item( $orientation, $item_id, $image_url, $title, $
 		?>
 			<div class="row">
 				<div class="img-col col-md-7 col-md-offset-0 col-sm-10 col-sm-offset-1 <?php if ( $alternate ) { ?>col-md-push-5<?php } ?>">
-					<img class="photo-essay-img" src="<?php echo $image_url; ?>" alt="<?php echo $title; ?>" title="<?php echo $title; ?>">
+					<img class="photo-essay-img" src="<?php echo $image_url; ?>" alt="<?php echo $alt; ?>" title="<?php echo $title; ?>">
 					<div class="carat"></div>
 				</div>
 				<div class="caption-col col-md-4 col-sm-12 <?php if ( $alternate ) { ?>col-md-pull-7 col-md-offset-1<?php } else { ?>col-md-offset-0<?php  } ?>">
@@ -202,7 +202,7 @@ function display_photo_essay_item( $orientation, $item_id, $image_url, $title, $
 		?>
 			<div class="row">
 				<div class="img-col col-md-12">
-					<img class="photo-essay-img" src="<?php echo $image_url; ?>" alt="<?php echo $title; ?>" title="<?php echo $title; ?>">
+					<img class="photo-essay-img" src="<?php echo $image_url; ?>" alt="<?php echo $alt; ?>" title="<?php echo $title; ?>">
 					<div class="carat"></div>
 				</div>
 				<div class="caption-col col-md-12">
@@ -236,6 +236,7 @@ function display_photo_essay( $photo_essay, $story=null ) {
 	$slide_order = array_filter( explode( ',', $slide_order ), 'strlen' );
 	$captions = get_post_meta( $photo_essay->ID, 'ss_slide_caption', TRUE );
 	$titles = get_post_meta( $photo_essay->ID, 'ss_slide_title', TRUE );
+	$alts = get_post_meta( $photo_essay->ID, 'ss_slide_alt', TRUE );
 	$images = get_post_meta( $photo_essay->ID, 'ss_slide_image', TRUE );
 	$photo_essay_markup = '';
 	$nav_markup = '';
@@ -251,6 +252,7 @@ function display_photo_essay( $photo_essay, $story=null ) {
 		$caption = wptexturize( do_shortcode( $captions[$i] ) );
 		$title = wptexturize( $titles[$i] );
 		$item_id = 'photo-' . sanitize_title( $title );
+		$alt = wptexturize( $alts[$i] ? $alts[$i] : $titles[$i] );
 		$orientation = '';
 		$alternate = false;
 
@@ -269,7 +271,7 @@ function display_photo_essay( $photo_essay, $story=null ) {
 			$alternate = true;
 		}
 
-		$photo_essay_markup .= display_photo_essay_item( $orientation, $item_id, $image_url, $title, $caption, $alternate );
+		$photo_essay_markup .= display_photo_essay_item( $orientation, $item_id, $image_url, $title, $alt, $caption, $alternate );
 
 		$nav_markup .= display_photo_essay_navitem( $item_id, $image_thumb_url );
 

--- a/versions/v4/functions.php
+++ b/versions/v4/functions.php
@@ -251,8 +251,8 @@ function display_photo_essay( $photo_essay, $story=null ) {
 		$image_thumb_url = $image_thumb[0];
 		$caption = wptexturize( do_shortcode( $captions[$i] ) );
 		$title = wptexturize( $titles[$i] );
-		$item_id = 'photo-' . sanitize_title( $title );
 		$alt = wptexturize( $alts[$i] ? $alts[$i] : $titles[$i] );
+		$item_id = 'photo-' . sanitize_title( $title ? $title : $i );
 		$orientation = '';
 		$alternate = false;
 

--- a/versions/v4/functions.php
+++ b/versions/v4/functions.php
@@ -388,7 +388,7 @@ function display_photo_essay_slideshow( $photo_essay, $slug=null, $caption_color
 				?>
 				<div class="ss-slide-wrapper">
 					<div class="ss-slide<?php echo $i + $photo_essay_offset == 0 ? ' ss-first-slide ss-current' : ''; ?><?php echo $i == $slide_count - 1 ? ' ss-last-slide' : ''; ?>" data-id="<?php echo $i + 1 + $photo_essay_offset; ?>" data-width="<?php echo $image[1]; ?>" data-height="<?php echo $image[2]; ?>">
-						<img src="<?php echo $image[0]; ?>" alt="<?php echo $alt; ?>" title="<?php echo $slide_title[$s]; ?>" />
+						<img src="<?php echo $image[0]; ?>" alt="<?php echo $alt; ?>" />
 					</div>
 				</div>
 			<?php

--- a/versions/v4/functions.php
+++ b/versions/v4/functions.php
@@ -236,7 +236,6 @@ function display_photo_essay( $photo_essay, $story=null ) {
 	$slide_order = array_filter( explode( ',', $slide_order ), 'strlen' );
 	$captions = get_post_meta( $photo_essay->ID, 'ss_slide_caption', TRUE );
 	$titles = get_post_meta( $photo_essay->ID, 'ss_slide_title', TRUE );
-	$alts = get_post_meta( $photo_essay->ID, 'ss_slide_alt', TRUE );
 	$images = get_post_meta( $photo_essay->ID, 'ss_slide_image', TRUE );
 	$photo_essay_markup = '';
 	$nav_markup = '';
@@ -251,7 +250,7 @@ function display_photo_essay( $photo_essay, $story=null ) {
 		$image_thumb_url = $image_thumb[0];
 		$caption = wptexturize( do_shortcode( $captions[$i] ) );
 		$title = wptexturize( $titles[$i] );
-		$alt = wptexturize( $alts[$i] ? $alts[$i] : $titles[$i] );
+		$alt = $title ? $title : get_post_meta($images[$i], '_wp_attachment_image_alt', TRUE);
 		$item_id = 'photo-' . sanitize_title( $title ? $title : $i );
 		$orientation = '';
 		$alternate = false;
@@ -348,7 +347,6 @@ function display_photo_essay_slideshow( $photo_essay, $slug=null, $caption_color
 	// Get rid of blank array entries
 	$slide_order = array_filter( explode( ',', $slide_order ), 'strlen' );
 	$slide_caption = get_post_meta( $photo_essay->ID, 'ss_slide_caption', TRUE );
-	$slide_alt = get_post_meta( $photo_essay->ID, 'ss_slide_alt', TRUE );
 	$slide_title = get_post_meta( $photo_essay->ID, 'ss_slide_title', TRUE );
 	$slide_image = get_post_meta( $photo_essay->ID, 'ss_slide_image', TRUE );
 
@@ -386,7 +384,7 @@ function display_photo_essay_slideshow( $photo_essay, $slug=null, $caption_color
 
 				$s = $slide_order[$i];
 				$image = wp_get_attachment_image_src( $slide_image[$s], 'full' );
-				$alt = $slide_alt[$s] ? $slide_alt[$s] : $slide_title[$s];
+				$alt = $slide_title[$s] ? $slide_title[$s] : get_post_meta($slide_image[$s], '_wp_attachment_image_alt', TRUE);
 				?>
 				<div class="ss-slide-wrapper">
 					<div class="ss-slide<?php echo $i + $photo_essay_offset == 0 ? ' ss-first-slide ss-current' : ''; ?><?php echo $i == $slide_count - 1 ? ' ss-last-slide' : ''; ?>" data-id="<?php echo $i + 1 + $photo_essay_offset; ?>" data-width="<?php echo $image[1]; ?>" data-height="<?php echo $image[2]; ?>">


### PR DESCRIPTION
Enhancements:
- Deprecated the Title field for Photo Essay slides
	- For backward compatibility, the title field has been left and will still be used as the slide image’s title and alt values if utilized
- Photo essay images will now be using the image’s media library alt text if present (and if the slide’s Title field is empty)

Bugfixes:
- @cjg89 fixed an issue where slides were not validating correctly, enabling slides with some fields left empty to be deleted upon post update