### PR TITLE
CSS, JS cache busting

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * READ ME, PLEASE:
  *
@@ -762,7 +762,17 @@ function output_header_markup($post) {
 		$fonts = unserialize( TEMPLATE_FONT_URLS );
 		if ( $fonts ) {
 			foreach ( $fonts as $name => $url ) {
-				$output .= '<link rel="stylesheet" href="'.$url.'" type="text/css" media="all" />';
+				// Our font handles should all use the naming convention
+				// `font-[slug]`. Try to create a stylesheet handle on the
+				// fly and compare with it, since `wp_style_is()` can't
+				// compare via asset URL:
+				$approximated_handle = 'font-' . sanitize_title( $name );
+
+				// Try to avoid loading fonts twice:
+				if ( ! wp_style_is( $approximated_handle, 'enqueued' ) ) {
+					$url = cache_bust_url( $url );
+					$output .= '<link rel="stylesheet" href="'.$url.'" type="text/css" media="all" />';
+				}
 			}
 		}
 
@@ -775,6 +785,7 @@ function output_header_markup($post) {
 	if ( $post->post_type == 'page' ) {
 		$page_stylesheet_url = Page::get_stylesheet_url( $post );
 		if ( !empty( $page_stylesheet_url ) ) {
+			$page_stylesheet_url = cache_bust_url( $page_stylesheet_url );
 			$output .= '<link rel="stylesheet" href="'.$page_stylesheet_url.'" type="text/css" media="all" />';
 		}
 	}
@@ -806,7 +817,8 @@ function output_header_markup($post) {
 					foreach ($fonts as $font) {
 						trim($font);
 						if (array_key_exists($font, $available_fonts)) {
-							$output .= '<link rel="stylesheet" href="'.$available_fonts[$font].'" type="text/css" media="all" />';
+							$font_url = cache_bust_url( $available_fonts[$font] );
+							$output .= '<link rel="stylesheet" href="'.$font_url.'" type="text/css" media="all" />';
 						}
 					}
 				}
@@ -824,13 +836,13 @@ function output_header_markup($post) {
 
 		// 3. Custom issue page-specific stylesheet
 		if ( (is_home() || $post->post_type == 'issue') && (uses_custom_template($post)) ) {
-			$home_stylesheet_url = Issue::get_home_stylesheet_url($post);
+			$home_stylesheet_url = cache_bust_url( Issue::get_home_stylesheet_url($post) );
 			$dev_issue_home_directory = get_post_meta($post->ID, 'issue_dev_home_asset_directory', TRUE);
 			if (!empty($home_stylesheet_url)) {
 				$output .= '<link rel="stylesheet" href="'.$home_stylesheet_url.'" type="text/css" media="all" />';
 			}
 			elseif ( DEV_MODE == 1 && !empty($dev_issue_home_directory) ) {
-				$dev_home_stylesheet_url = THEME_DEV_URL.'/'.$dev_issue_home_directory.'issue-cover.css';
+				$dev_home_stylesheet_url = cache_bust_url( THEME_DEV_URL.'/'.$dev_issue_home_directory.'issue-cover.css' );
 				if (curl_exists($dev_home_stylesheet_url)) {
 					$output .= '<link rel="stylesheet" href="'.$dev_home_stylesheet_url.'" type="text/css" media="all" />';
 				}
@@ -839,13 +851,13 @@ function output_header_markup($post) {
 
 		// 4. Custom story stylesheet
 		if( $post->post_type == 'story' && uses_custom_template($post) ) {
-			$story_stylesheet_url = Story::get_stylesheet_url($post);
+			$story_stylesheet_url = cache_bust_url( Story::get_stylesheet_url($post) );
 			$dev_issue_directory = get_post_meta($post->ID, 'story_dev_directory', TRUE);
 			if ( !empty($story_stylesheet_url) ) {
 				$output .= '<link rel="stylesheet" href="'.$story_stylesheet_url.'" type="text/css" media="all" />';
 			}
 			elseif ( (DEV_MODE == 1) && !empty($dev_issue_directory) ) {
-				$dev_story_stylesheet_url = THEME_DEV_URL.'/'.$dev_issue_directory.$post->post_name.'.css';
+				$dev_story_stylesheet_url = cache_bust_url( THEME_DEV_URL.'/'.$dev_issue_directory.$post->post_name.'.css' );
 				if (curl_exists($dev_story_stylesheet_url)) {
 					$output .= '<link rel="stylesheet" href="'.$dev_story_stylesheet_url.'" type="text/css" media="all" />';
 				}

--- a/functions/base.php
+++ b/functions/base.php
@@ -71,10 +71,7 @@ class Config {
 
 		$is_admin = ( is_admin() or is_login() );
 
-		$theme         = wp_get_theme( 'Pegasus-Theme' );
-		$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
-		$root_url      = get_home_url();
-		$cache_bust    = $theme_version && strpos( $attr['src'], $root_url ) !== false ? $theme_version : null;
+		$cache_bust = get_cache_bust( $attr['src'] ) ?: null;
 
 		if (
 			( $attr['admin'] and $is_admin ) or
@@ -117,10 +114,7 @@ class Config {
 
 		$is_admin = ( is_admin() or is_login() );
 
-		$theme         = wp_get_theme( 'Pegasus-Theme' );
-		$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
-		$root_url      = get_home_url();
-		$cache_bust    = $theme_version && strpos( $attr['src'], $root_url ) !== false ? $theme_version : null;
+		$cache_bust = get_cache_bust( $attr['src'] ) ?: null;
 
 		if (
 			( $attr['admin'] and $is_admin ) or
@@ -930,6 +924,49 @@ function set_defaults_for_options(){
 			update_option(THEME_OPTIONS_NAME, $values);
 		}
 	}
+}
+
+
+/**
+ * Returns a cache busting string for theme-enqueued
+ * stylesheets and scripts.
+ *
+ * @since 5.0.0
+ * @author Jo Dickson
+ * @param string $asset_url URL for an enqueued asset
+ * @return string
+ */
+function get_cache_bust( $asset_url ) {
+	$theme         = wp_get_theme( 'Pegasus-Theme' );
+	$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
+	$root_url      = get_home_url();
+
+	return $theme_version && strpos( $asset_url, $root_url ) !== false ? $theme_version : '';
+}
+
+
+/**
+ * Returns the provided asset URL with cache busting applied.
+ *
+ * @since 5.0.0
+ * @author Jo Dickson
+ * @param string $asset_url URL for an enqueued asset
+ * @return string
+ */
+function cache_bust_url( $asset_url ) {
+	$cache_busted_url = $asset_url;
+	$cache_bust = get_cache_bust( $asset_url );
+
+	if ( $cache_bust ) {
+		$cache_busted_url = add_query_arg(
+			array(
+				'ver' => $cache_bust
+			),
+			$cache_busted_url
+		);
+	}
+
+	return $cache_busted_url;
 }
 
 

--- a/functions/base.php
+++ b/functions/base.php
@@ -71,12 +71,17 @@ class Config {
 
 		$is_admin = ( is_admin() or is_login() );
 
+		$theme         = wp_get_theme( 'Pegasus-Theme' );
+		$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
+		$root_url      = get_home_url();
+		$cache_bust    = $theme_version && strpos( $attr['src'], $root_url ) !== false ? $theme_version : null;
+
 		if (
 			( $attr['admin'] and $is_admin ) or
 			( !$attr['admin'] and !$is_admin )
 		) {
 			wp_deregister_style( $attr['name'] );
-			wp_enqueue_style( $attr['name'], $attr['src'], null, null, $attr['media'] );
+			wp_enqueue_style( $attr['name'], $attr['src'], null, $cache_bust, $attr['media'] );
 		}
 	}
 
@@ -112,13 +117,18 @@ class Config {
 
 		$is_admin = ( is_admin() or is_login() );
 
+		$theme         = wp_get_theme( 'Pegasus-Theme' );
+		$theme_version = ( $theme instanceof WP_Theme ) ? $theme->get( 'Version' ) : false;
+		$root_url      = get_home_url();
+		$cache_bust    = $theme_version && strpos( $attr['src'], $root_url ) !== false ? $theme_version : null;
+
 		if (
 			( $attr['admin'] and $is_admin ) or
 			( !$attr['admin'] and !$is_admin )
 		) {
 			// Override previously defined scripts
 			wp_deregister_script( $attr['name'] );
-			wp_enqueue_script( $attr['name'], $attr['src'], null, null, True );
+			wp_enqueue_script( $attr['name'], $attr['src'], null, $cache_bust, True );
 		}
 	}
 }


### PR DESCRIPTION
- Added utility functions for retrieving a cache bust string (the current theme version number in style.css) and for applying said string to a provided URL.
- Applied cache busting to assets enqueued via the `Config` object, as well as assets hard-coded into the document head via `output_header_markup()`.
- Updated `output_header_markup()` to check if a font in `TEMPLATE_FONT_URLS` has already been enqueued before printing a hard-coded `<link>` tag for it in the document head (thus avoiding duplicates.)

These changes affect all versions and all stories.