### PR TITLE
Hf - changing the H2 tag from headline (In this issue section)

### DIFF
--- a/versions/v1/header.php
+++ b/versions/v1/header.php
@@ -83,7 +83,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="span12">
-							<h2 class="section-title" id="pulldown-heading">In This Issue</h2>
+							<span class="section-title" id="pulldown-heading">In This Issue</span>
 						</div>
 					</div>
 				</div>

--- a/versions/v2/header.php
+++ b/versions/v2/header.php
@@ -83,7 +83,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="span12">
-							<h2 class="section-title" id="pulldown-heading">In This Issue</h2>
+							<span class="section-title" id="pulldown-heading">In This Issue</span>
 						</div>
 					</div>
 				</div>

--- a/versions/v3/header.php
+++ b/versions/v3/header.php
@@ -82,7 +82,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="col-md-12 col-sm-12">
-							<h2 class="section-title" id="pulldown-heading">In This Issue</h2>
+							<span class="section-title" id="pulldown-heading">In This Issue</span>
 						</div>
 					</div>
 				</div>

--- a/versions/v4/header.php
+++ b/versions/v4/header.php
@@ -14,7 +14,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="col-md-12 col-sm-12">
-							<h2 class="section-title" id="pulldown-heading">In This Issue</h2>
+							<span class="section-title" id="pulldown-heading">In This Issue</span>
 						</div>
 					</div>
 				</div>

--- a/versions/v5/header.php
+++ b/versions/v5/header.php
@@ -13,7 +13,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="col-md-12 col-sm-12">
-							<h2 class="section-title" id="pulldown-heading">In This Issue</h2>
+							<span class="section-title" id="pulldown-heading">In This Issue</span>
 						</div>
 					</div>
 				</div>

--- a/versions/v6/header.php
+++ b/versions/v6/header.php
@@ -38,7 +38,7 @@
 					</div>
 					<div class="container">
 						<div class="text-uppercase my-4 py-2" id="pulldown-heading">
-							<span class="mr-1 h2">In This Issue</span>
+							<span class="h2 mr-1">In This Issue</span>
 							<span class="d-inline-block font-size-lg text-transform-none"><?php echo $relevant_issue->post_title; ?></span>
 						</div>
 					</div>

--- a/versions/v6/header.php
+++ b/versions/v6/header.php
@@ -37,10 +37,10 @@
 						</button>
 					</div>
 					<div class="container">
-						<h2 class="text-uppercase my-4 py-2" id="pulldown-heading">
-							<span class="mr-1">In This Issue</span>
+						<div class="text-uppercase my-4 py-2" id="pulldown-heading">
+							<span class="mr-1 h2">In This Issue</span>
 							<span class="d-inline-block font-size-lg text-transform-none"><?php echo $relevant_issue->post_title; ?></span>
-						</h2>
+						</div>
 					</div>
 					<div class="story-list-wrap">
 						<?php echo display_story_list( $relevant_issue ); ?>


### PR DESCRIPTION
- h2 tag was replaced with span in versions 1 to 5.
- h2 was replaced with div in version 6. 