### PR TITLE
Added public properties for dynamically created ones

### DIFF
--- a/functions/base.php
+++ b/functions/base.php
@@ -136,6 +136,12 @@ class Config {
  * @author Jared Lang
  * */
 abstract class Field {
+	public $name;
+	public $id;
+	public $value;
+	public $description;
+	public $default;
+
 	protected function check_for_default() {
 		if ( ( $this->value === null || $this->value === '' ) && isset( $this->default ) ) {
 			$this->value = $this->default;
@@ -190,6 +196,8 @@ abstract class Field {
  * @author Jared Lang
  * */
 abstract class ChoicesField extends Field{
+	public $choices;
+
 	// Ensure 'default' value is added to choices if it isn't already
 	protected function add_default_to_choices() {
 		if ( isset( $this->default ) && !array_key_exists( $this->default, $this->choices ) ) {


### PR DESCRIPTION
- Fixes #151 
- You're not able to "dynamically" create properties as of PHP 8, so public properties need to be declared in the class space before assigning a value to them.
- The deprecation notices were being thrown on the child classes, but by adding the property to the parent/abstract classes, then inherit to the children.